### PR TITLE
fix(deps): pin cisco-ai-mcp-scanner==4.4.0 to unblock daily pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       patch-updates:
         update-types:
           - "patch"
+    ignore:
+      # cisco-ai-mcp-scanner >=4.5.0 pins litellm==1.83.0, which conflicts
+      # with guardrails-ai 0.10.0 (litellm<1.82.6). Re-evaluate when either
+      # package relaxes its litellm pin.
+      - dependency-name: "cisco-ai-mcp-scanner"
+        versions: [">=4.5.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.42.84
 cedarpy==4.8.0
 claude-agent-sdk==0.1.56
 deepeval==3.9.5
-cisco-ai-mcp-scanner==4.6.0
+cisco-ai-mcp-scanner==4.4.0
 deepteam==1.0.6
 arize-phoenix==14.2.1
 arize-phoenix-otel==0.15.0


### PR DESCRIPTION
## Summary
- Pin \`cisco-ai-mcp-scanner==4.4.0\` (down from 4.6.0). Versions 4.5.0+ pin \`litellm==1.83.0\`, which conflicts with \`guardrails-ai 0.10.0\` (\`litellm>=1.37.14,<1.82.6\`). Result: \`pip install -r pipeline/requirements.txt\` aborts with \`ResolutionImpossible\`.
- Add a Dependabot ignore rule blocking \`cisco-ai-mcp-scanner>=4.5.0\` until either package relaxes its litellm pin.

## Background
The scheduled \`Vectimus Sentinel\` workflow has been failing every day since 2026-04-24, when #51 (titled "bump 4.4.0 → 4.5.0" but actually bumped to 4.6.0 due to a release that landed while the PR was open) merged. Failure log: pip ResolutionImpossible in \`Install pipeline dependencies\`.

\`guardrails-ai\` 0.10.0 is the latest on PyPI, so we can't bump our way out on that side; reverting cisco is the only viable fix today.

## Test plan
- [ ] CI \`Install pipeline dependencies\` step succeeds on this PR.
- [ ] After merge, next scheduled \`Vectimus Sentinel\` run completes without the pip resolution error.
- [ ] Confirm no functional regression from cisco-ai-mcp-scanner 4.6.0 → 4.4.0 (release notes: https://github.com/cisco-ai-defense/mcp-scanner/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)