### PR TITLE
fix(ci): stop dependabot PRs failing claude-review; survive research-scout overrun

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: >
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request' &&
+       github.actor != 'dependabot[bot]') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude'))

--- a/pipeline/agents/threat_hunter.py
+++ b/pipeline/agents/threat_hunter.py
@@ -126,21 +126,27 @@ async def _run_research_scout(
         f"Write your output JSON array to {output_path}"
     )
 
-    await _run_sub_agent(
-        name="research-scout",
-        config=config,
-        system_prompt=system_prompt,
-        user_message=user_message,
-        allowed_tools=[
-            "WebSearch",
-            "WebFetch",
-            "Read",
-            "Write",
-            "Bash",
-            "mcp__sentinel__r2_put",
-        ],
-        max_turns=20,
-    )
+    try:
+        await _run_sub_agent(
+            name="research-scout",
+            config=config,
+            system_prompt=system_prompt,
+            user_message=user_message,
+            allowed_tools=[
+                "WebSearch",
+                "WebFetch",
+                "Read",
+                "Write",
+                "Bash",
+                "mcp__sentinel__r2_put",
+            ],
+            max_turns=30,
+        )
+    except Exception as e:
+        # The CLI exits non-zero when the scout runs out of turns on busy
+        # news days; fall through to the output-file check rather than
+        # failing the whole pipeline run.
+        logger.error("[research-scout] Query aborted; using any partial output: %s", e)
 
     if not output_path.exists():
         logger.warning("Research Scout did not write output file; returning empty list")


### PR DESCRIPTION
Two CI reliability fixes:

**1. Dependabot PRs no longer get an automatic red X.**
`claude-code-action` rejects workflows initiated by non-human actors ("Workflow initiated by non-human actor: dependabot"), and dependabot-triggered runs receive no repository secrets anyway (`claude_code_oauth_token` arrives empty). Every dependabot PR therefore failed the `claude-review` check regardless of content. The job now skips for `dependabot[bot]`.

**2. Daily pipeline survives the research scout running out of turns.**
On busy threat-news days the research-scout sub-agent hits its turn ceiling and the Claude CLI exits non-zero, which crashed `python -m pipeline threat-hunter` and failed the whole run (June 1, 3, 4, 5, 8 failures all show `Agent SDK query failed after ~150 messages: Command failed with exit code 1`). The query is now wrapped so the stage falls through to the existing output-file check (partial or empty findings) instead of failing, and the ceiling is raised from 20 to 30 turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)