### PR TITLE
fix(deps): pin pydantic-ai-slim<2 to unblock daily pipeline

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -6,6 +6,9 @@ cisco-ai-mcp-scanner==4.4.0
 deepteam==1.0.6
 arize-phoenix==17.5.0
 arize-phoenix-otel==0.16.1
+# arize-phoenix 17.5.0 imports MCPServerStreamableHTTP, removed in pydantic-ai-slim 2.0.
+# Cap below 2 until phoenix is compatible, else pytest collection (phoenix plugin) fails.
+pydantic-ai-slim<2
 openinference-instrumentation-claude-agent-sdk==0.1.6
 fastmcp==3.4.2
 httpx==0.28.1


### PR DESCRIPTION
## Problem

Every scheduled `Vectimus Sentinel` run has hard-failed since **2026-06-26**, dying in the `checks` job at *Run tests* before any agent runs:

```
ImportError: cannot import name 'MCPServerStreamableHTTP' from 'pydantic_ai.mcp'
```

## Root cause

Transitive dependency drift, not our code:

- `arize-phoenix==17.5.0` requires only `pydantic-ai-slim>=1.95.0` (no upper bound), so pip floats it to the 2.x line.
- **`pydantic-ai-slim 2.0.0` removed `MCPServerStreamableHTTP`** (verified: present in 1.99.0, gone in 2.0.0).
- `phoenix.server.app` still imports that symbol, and phoenix registers a **pytest11 plugin** — so pytest can't even start collecting → `checks` exits 1 → the whole pipeline is blocked.

## Fix

Pin `pydantic-ai-slim<2`. Combined with phoenix's `>=1.95.0`, pip resolves to `1.99.0`, where the symbol still exists. Remove the cap once arize-phoenix ships a pydantic-ai 2.x-compatible release (open bump PR #124 → 17.9.0 does not necessarily fix this on its own).

## Testing

CI `checks` job (pytest collection) will validate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)