### PR TITLE
feat(pipeline): skip review gate when nothing is actionable

### DIFF
--- a/.github/workflows/sentinel-pipeline.yml
+++ b/.github/workflows/sentinel-pipeline.yml
@@ -53,6 +53,7 @@ jobs:
     timeout-minutes: 35
     outputs:
       review_issue: ${{ steps.create-review-issue.outputs.issue_number }}
+      skip_review: ${{ steps.create-review-issue.outputs.skip_review }}
 
     steps:
       - name: Checkout sentinel
@@ -129,6 +130,11 @@ jobs:
   # -----------------------------------------------------------------------
   review-gate:
     needs: threat-hunter
+    # Skip the human gate (and the downstream policy/analyst stages that depend
+    # on it) when the threat-hunter surfaced nothing actionable or content-worthy.
+    # Fail-safe: only an explicit "true" skips; a missing/failed output keeps the
+    # gate. Findings are still recorded by the publish stage regardless.
+    if: needs.threat-hunter.outputs.skip_review != 'true'
     runs-on: ubuntu-latest
     environment: sentinel-review
     steps:

--- a/pipeline/hitl_issue.py
+++ b/pipeline/hitl_issue.py
@@ -53,6 +53,26 @@ def _find_findings_file() -> Path:
     raise FileNotFoundError("No findings file found")
 
 
+def _classify(findings: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Split findings into (actionable policy work, content-worthy advisories).
+
+    Out-of-scope findings are never actionable or content-worthy for Vectimus,
+    so they never on their own warrant a human review gate.
+    """
+    actionable = [
+        f
+        for f in findings
+        if f.get("recommended_action") != "no_change"
+        and f.get("enforcement_scope") != "out_of_scope"
+    ]
+    content_worthy = [
+        f
+        for f in findings
+        if f.get("content_worthy") and f.get("enforcement_scope") != "out_of_scope"
+    ]
+    return actionable, content_worthy
+
+
 def _build_issue_body(findings: list[dict]) -> str:
     """Build the issue body with a checkbox per finding.
 
@@ -83,12 +103,7 @@ def _build_issue_body(findings: list[dict]) -> str:
         lines.append("")
 
     # Summary stats
-    actionable = [f for f in findings if f.get("recommended_action") != "no_change"]
-    content_worthy = [
-        f
-        for f in findings
-        if f.get("content_worthy") and f.get("enforcement_scope") != "out_of_scope"
-    ]
+    actionable, content_worthy = _classify(findings)
     pending = [
         f
         for f in findings
@@ -117,6 +132,23 @@ def create() -> None:
     if not findings:
         print("No findings to review, skipping issue creation")
         _set_output("issue_number", "")
+        _set_output("skip_review", "true")
+        return
+
+    # Decide whether a human review gate is warranted. Only findings that are
+    # actionable (policy work) or content-worthy (advisories) require review;
+    # a run that is all out-of-scope / no_change noise should not block the
+    # pipeline waiting for approval that never comes. `skip_review` is worded
+    # fail-safe: the workflow only skips the gate on an explicit "true", so any
+    # error here leaves the human gate in place.
+    actionable, content_worthy = _classify(findings)
+    if not actionable and not content_worthy:
+        print(
+            f"None of {len(findings)} findings are actionable or content-worthy; "
+            "skipping review gate. Findings are still recorded by the publish stage."
+        )
+        _set_output("issue_number", "")
+        _set_output("skip_review", "true")
         return
 
     body = _build_issue_body(findings)
@@ -140,6 +172,7 @@ def create() -> None:
     print(f"Created review issue #{number}: {issue_number}")
 
     _set_output("issue_number", number)
+    _set_output("skip_review", "false")
 
     # Also add the issue link to the job summary
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")

--- a/tests/test_hitl_issue.py
+++ b/tests/test_hitl_issue.py
@@ -1,0 +1,71 @@
+"""Tests for the HITL review-gate classification logic.
+
+The pipeline should only block on the human review gate when the threat-hunter
+surfaced something worth reviewing. A run that is all out-of-scope / no_change
+noise must NOT wait for an approval that never comes.
+"""
+
+from __future__ import annotations
+
+from pipeline.hitl_issue import _classify
+
+
+def _finding(**overrides: object) -> dict:
+    base = {
+        "vtms_id": "VTMS-2026-0001",
+        "title": "Example",
+        "severity": 3,
+        "enforcement_scope": "full",
+        "recommended_action": "no_change",
+        "content_worthy": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_actionable_when_policy_change_and_in_scope() -> None:
+    actionable, content = _classify([_finding(recommended_action="new_policy")])
+    assert len(actionable) == 1
+    assert content == []
+
+
+def test_out_of_scope_never_actionable() -> None:
+    # Even a policy-changing recommendation is not actionable if out of scope.
+    actionable, content = _classify(
+        [_finding(enforcement_scope="out_of_scope", recommended_action="new_policy")]
+    )
+    assert actionable == []
+    assert content == []
+
+
+def test_content_worthy_in_scope_is_flagged() -> None:
+    actionable, content = _classify([_finding(content_worthy=True)])
+    assert actionable == []
+    assert len(content) == 1
+
+
+def test_out_of_scope_content_worthy_is_ignored() -> None:
+    actionable, content = _classify(
+        [_finding(enforcement_scope="out_of_scope", content_worthy=True)]
+    )
+    assert content == []
+
+
+def test_all_noise_needs_no_review() -> None:
+    # The scenario that used to strand runs "waiting" for a week: every finding
+    # is out-of-scope / no_change. Nothing actionable, nothing content-worthy.
+    findings = [
+        _finding(vtms_id="VTMS-2026-0100", enforcement_scope="out_of_scope"),
+        _finding(vtms_id="VTMS-2026-0101", enforcement_scope="tool_calling_only"),
+    ]
+    actionable, content = _classify(findings)
+    assert not actionable and not content  # -> workflow sets skip_review=true
+
+
+def test_mixed_run_needs_review() -> None:
+    findings = [
+        _finding(vtms_id="VTMS-2026-0100", enforcement_scope="out_of_scope"),
+        _finding(vtms_id="VTMS-2026-0101", recommended_action="new_policy"),
+    ]
+    actionable, content = _classify(findings)
+    assert len(actionable) == 1


### PR DESCRIPTION
## Problem

The `review-gate` job blocks on human approval **unconditionally** (`needs: threat-hunter`, no `if:`). On days when the threat-hunter surfaces only `out_of_scope` / `no_change` findings, there is nothing for a human to approve — yet the run sits in `waiting` until GitHub times it out at **30 days**, and its review issue is orphaned.

This is exactly what happened to the 2026-06-19/20/21 runs (0 actionable, 0 content-worthy), part of a backlog of 17 stranded `waiting` runs.

## Change

- `hitl_issue.py` emits a new fail-safe output **`skip_review`**, `true` only when *no* finding is actionable (in-scope policy work) **or** content-worthy (in-scope advisory).
- The workflow skips `review-gate` — and therefore the dependent `policy-engineer` / `threat-analyst` stages — when `skip_review == 'true'`.
- Findings are still recorded, committed, and included in the daily summary by the `publish` stage, which does **not** depend on the gate (`if: always() && … != 'cancelled'`; skipped ≠ cancelled).

### Fail-safe by construction

The gate is skipped **only** on an explicit `skip_review == 'true'`. A failed or missing output (the `create-review-issue` step is `continue-on-error: true`) leaves the human review gate fully in place. When in doubt, a human still reviews.

### Refactor + tests

Extracted the actionable / content-worthy split into `_classify()` (now shared with the issue-body summary, so the displayed counts and the gate decision can't drift apart) and added `tests/test_hitl_issue.py` covering the skip/keep decision — including the all-noise case that used to strand runs.

## Note

Out-of-scope findings are now excluded from the "Actionable (policy work)" count in the review issue summary (previously any `recommended_action != no_change` counted, regardless of scope). This matches intent — an out-of-scope finding is not policy-actionable — and did not change the counts on recent real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
